### PR TITLE
fix: navigation is now in a container

### DIFF
--- a/src/app/navigation/navigation.component.html
+++ b/src/app/navigation/navigation.component.html
@@ -1,5 +1,5 @@
 <nav class="navigation__nav navbar navbar-expand-sm">
-  <div class="container-fluid">
+  <div class="container">
     <a routerLink="" class="navbar-brand text-light m-0 me-sm-3"><img src="assets/img/LOGO-SPINE-DARK-BG.png" width="24"
                                                                       height="30" alt="i.Question"></a>
     <button type="button" class="navbar-toggler" (click)="collapsed = !collapsed">


### PR DESCRIPTION
<!--- Begin altijd met het nummer van je issue gevolgd door een korte omschrijving in de titel hierboven -->
 
## Omschrijving

Put navigation in a container instead of in a fluid container making it easier for wide monitors to view to navbar

## Design Review
Een Design Review wordt gedaan bij stories waar css wordt toegevoegd/aangepast/verwijderd. Upload screenshots van de functionaliteit in de volgende resoluties:
* 375px (mobile phone)
![image](https://user-images.githubusercontent.com/79027654/213885318-7210cd31-f0ce-42d1-8062-c0683b5c08e9.png)

* 768px (tablet portrait)
![image](https://user-images.githubusercontent.com/79027654/213885307-6666086a-b593-45cc-9d0d-2f2c8b2505e0.png)

* 1024px (tablet landscape - laptop)
![image](https://user-images.githubusercontent.com/79027654/213885295-7ecc36a1-4515-4bb7-b74c-eee74a1509e2.png)

* 1440px (laptop - desktop)
![image](https://user-images.githubusercontent.com/79027654/213885273-fef6fb46-a198-46de-93c6-71f7b65530d0.png)
 
## How-to-demo
 
1. View navigation after logging in
 
## Checklist
 
Loop alle onderstaande punten na en zet een `x` in alle vakjes die van toepassing zijn.
 
- [x] Mijn pull request is voor één story/feature.
- [x] Elke individuele commit in dit pull request is logisch.
- [x] Alle code, documentatie en commits zijn in het Engels.
- [x] Ik heb overbodige/ongebruikte code weggegooid.
- [x] Mijn pull-request verwerkt geen nieuwe gevoelige informatie zonder dat ik dit heb doorgesproken met een lid van het security-team.
- [x] Ik heb tests toegevoegd of bijgewerkt om mijn wijzigingen te testen.
- [x] Als mijn wijziging veranderingen in de documentatie vereist, dan heb ik dat bijgewerkt.